### PR TITLE
bug fix

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -76,7 +76,7 @@ class DBStatusRepository {
       .from("votes")
       .groupBy("status");
 
-    if (!lastVoteRecords) {
+    if (lastVoteRecords.length === 0) {
       const lastVoteRecord = await knex
         .select("status")
         .where({ park_id })


### PR DESCRIPTION
I created a small bug with the port to knex. If nobody votes for a splashpad status in 24 hours, I think we want to show that it's working if the last vote was working. If the last vote was not working then it should show unknown. This small change fixes that issue. 